### PR TITLE
github prs output simplification

### DIFF
--- a/commands/github-prs/index.js
+++ b/commands/github-prs/index.js
@@ -14,7 +14,7 @@
 // @raycast.authorURL https://github.com/dev99problems
 
 const { Octokit } = require('octokit')
-const { displayPRs, displaySectionName } = require('./output.js')
+const { displayPrs, displaySectionName } = require('./output.js')
 const ENV = require('./env')
 
 // Create a personal access token at https://github.com/settings/tokens/new?scopes=repo
@@ -27,7 +27,7 @@ const extractPrData = pr => ({
   state: pr.state,
 })
 
-const getRepoOpenPRs = async ({ owner, repo, state = 'open', creator = ENV.creator }) => {
+const getRepoOpenPrs = async ({ owner, repo, state = 'open', creator = ENV.creator }) => {
   const { data } = (await octokit.request('GET /repos/{owner}/{repo}/issues', {
     owner,
     repo,
@@ -39,11 +39,11 @@ const getRepoOpenPRs = async ({ owner, repo, state = 'open', creator = ENV.creat
   return data
 }
 
-const getAllPRs = async (owner, reposList) => {
+const getSectionProjectsPrs = async (owner, reposList) => {
   let result = {}
 
   for (const repo of reposList) {
-    const openPRs = await getRepoOpenPRs({ owner, repo })
+    const openPRs = await getRepoOpenPrs({ owner, repo })
     if (openPRs && openPRs.length) {
       result[repo] = openPRs.map(extractPrData)
     }
@@ -55,13 +55,16 @@ const getAllPRs = async (owner, reposList) => {
 ;(async () => {
   try {
     const { projects } = ENV
-    for (const section of Object.keys(projects)) {
+    const keys = Object.keys;
+    
+    for (const section of keys(projects)) {
       const { owner, repos } = projects[section]
 
-      const allPRs = await getAllPRs(owner, repos)
+      const allPRs = await getSectionProjectsPrs(owner, repos)
+      const anyPrInSection = !!keys(allPRs)?.length
 
-      displaySectionName(section)
-      displayPRs(allPRs)
+      anyPrInSection && displaySectionName(section)
+      displayPrs(allPRs)
     }
   } catch (err) {
     console.error(err)

--- a/commands/github-prs/index.js
+++ b/commands/github-prs/index.js
@@ -14,7 +14,7 @@
 // @raycast.authorURL https://github.com/dev99problems
 
 const { Octokit } = require('octokit')
-const { displayOutput, colors } = require('./output.js')
+const { displayPRs, displaySectionName } = require('./output.js')
 const ENV = require('./env')
 
 // Create a personal access token at https://github.com/settings/tokens/new?scopes=repo
@@ -55,14 +55,13 @@ const getAllPRs = async (owner, reposList) => {
 ;(async () => {
   try {
     const { projects } = ENV
-    for (const project of Object.keys(projects)) {
-      const color = project === 'personal' ? colors.FgGreen : colors.FgRed
-      console.log(color + project.toUpperCase() + ':')
-      
-      const { owner, repos } = projects[project]
+    for (const section of Object.keys(projects)) {
+      const { owner, repos } = projects[section]
 
       const allPRs = await getAllPRs(owner, repos)
-      displayOutput(allPRs)
+
+      displaySectionName(section)
+      displayPRs(allPRs)
     }
   } catch (err) {
     console.error(err)

--- a/commands/github-prs/output.js
+++ b/commands/github-prs/output.js
@@ -22,7 +22,7 @@ const prepareForOutput = (pr, idx) => {
   return row
 }
 
-const displayOutput = allPRs => {
+const displayPrs = allPRs => {
   Object.keys(allPRs).forEach(repoName => {
     const repoPRs = allPRs[repoName]
     const repositoryName = `${FgBlue}${repoName}:\n`
@@ -34,5 +34,14 @@ const displayOutput = allPRs => {
   })
 }
 
-exports.displayOutput = displayOutput
-exports.colors = colors
+const displaySectionName = section => {
+  const colorMap = {
+    work: FgRed,
+    personal: FgGreen,
+  }
+  
+  console.log(colorMap[section] + section.toUpperCase() + ':')
+}
+
+exports.displayPrs = displayPrs
+exports.displaySectionName = displaySectionName


### PR DESCRIPTION
### Description
Minor `methods` renaming — no more `*PRs` and use `Prs` instead

### What was done
* **[github_prs]** `rename` output methods
* **[github_prs]** `remove` output of section name, when it is empty
