### PR TITLE
add: basic video:converter implementation in ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,19 @@ module.exports = {
 }
 ```
 
+
+### 📹video:convert
+
+TBD
+
+
 ### ✂️ trim:link
 
 Trims the meta data from [Great Suspender](https://chrome.google.com/webstore/detail/the-great-suspender/jaekigmcljkkalnicnjoafgfjoefkpeg?hl=en) links.
 Works pretty the same as [great-suspender-link-trimmer](https://github.com/dev99problems/great-suspender-link-trimmer)
 
 https://user-images.githubusercontent.com/6503508/137031968-ce1e2837-5a70-4e11-939f-97150e248289.mov
+
 
 ## Related Links 
 Here is `repo` of [community driven scripts](https://github.com/raycast/script-commands) for `Raycast`

--- a/commands/video-converter/converter.rb
+++ b/commands/video-converter/converter.rb
@@ -1,0 +1,62 @@
+INPUT = './input'
+OUTPUT = './output'
+
+module Helpers
+  def created_today?(date)
+    today = Time.now
+    date.day == today.day && date.month == today.month
+  end
+
+  def make_readable_size(size_in_bytes)
+    suffix = %W(B KB MB)
+    idx = 0
+    rest = 0
+    size = size_in_bytes
+
+    while size / 1024 > 1
+      idx += 1
+      new_size = size / 1024
+      rest = size - new_size * 1024
+      size = new_size
+    end
+
+    "#{size}.#{rest / 10} #{suffix[idx]}"
+  end
+
+  def get_size(filename)
+    File.exist?(filename) ? make_readable_size(File.size(filename)) : 'NA'
+  end
+end
+
+include Helpers
+
+def get_path(filename)
+  input_filepath = "#{INPUT}/#{filename}",
+  output_filepath = "#{OUTPUT}/#{filename}"
+end
+
+def convert(filename)
+  input, output = get_path(filename)
+  command = "ffmpeg -i #{input.inspect} -hide_banner -loglevel error -vf scale=1536:1024 -preset slow -crf 18 #{output.inspect} -y"
+  # async
+  fork { exec(command) }
+  # sync
+  # system(command)
+end
+
+input_files = Dir.children(INPUT)
+
+input_files.each do |filename|
+  input, output = get_path(filename)
+
+  creation_date = File.birthtime(input)
+
+  if Helpers::created_today?(creation_date)
+    p filename
+    convert(filename)
+
+    p ": #{Helpers::get_size(input)} -> #{Helpers::get_size(output)}"
+  end
+end
+
+


### PR DESCRIPTION
### Description
Adds a new fellow on the block — **video:convert** command, which crawls the default directory and converts
_**today's**_ new Screen recordings