### PR TITLE
init version of synclair

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ https://user-images.githubusercontent.com/6503508/187051414-5b14293a-d74d-4f36-b
 
 <br/>
 
+### 🛫 synclair:(up & down)
+
+Simply configured `rsync` command to sync local folder, full of `*.md` notes to iCloud.
+
+<br/>
+
 ### 🤖 pulls:open
 
 Gets all open `Github pull-requests` of author, from a `list of projects`, grouped by the `section`.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ https://user-images.githubusercontent.com/6503508/187051414-5b14293a-d74d-4f36-b
 
 Simply configured `rsync` command to sync local folder, full of `*.md` notes to iCloud.
 
+<img width="1084" alt="synclair_dry_run" src="https://user-images.githubusercontent.com/6503508/190903826-73410d90-0156-4616-9ebf-43bd7c8aa44d.png">
+
 <br/>
 
 ### 🤖 pulls:open

--- a/commands/synclair/README.md
+++ b/commands/synclair/README.md
@@ -1,0 +1,26 @@
+# Synclair — here to sync notes to iCloud
+
+## Preface
+
+Usually I create a lot of notes in `*.md` format,
+so the main reason for this script:
+* have them synced with iCloud, back & forward
+* have those notes avaialbe across multiple devices
+
+## Prerequisites
+
+To have `rsync` installed, usually can be done with
+```shell
+brew install rsync
+```
+
+## Config
+
+There are 2 folders: `LOCAL` and `REMOTE`, that should be configured beforehand.
+
+They should be set without the trailing `/`, it will be handled by script itself, **e.g.**
+
+`LOCAL="/Users/<USER>/Documents/learn/notes"`
+
+`REMOTE="/Users/<USER>/Library/Mobile Documents/com~apple~CloudDocs/"`
+

--- a/commands/synclair/synclair_down.sh
+++ b/commands/synclair/synclair_down.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env zsh
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title synclair:down
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🛬
+# @raycast.description Upstream sync of your notes
+
+# Documentation:
+# @raycast.author Eugene Chulkov
+# @raycast.authorURL https://github.com/dev99problems
+
+LOCAL="/Users/<USER>/<SOME_PATH>/notes"
+REMOTE="/Users/<USER>/Library/Mobile Documents/com~apple~CloudDocs/notes"
+
+# for debugging
+# rsync -vran --exclude={".DS_Store",".idea"} "${REMOTE}/" $LOCAL
+
+# for doing stuff
+rsync -ra --exclude={".DS_Store",".idea"} "${REMOTE}/" $LOCAL
+
+

--- a/commands/synclair/synclair_up.sh
+++ b/commands/synclair/synclair_up.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env zsh
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title synclair:up
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🛫
+# @raycast.description Upstream sync of your notes
+
+# Documentation:
+# @raycast.author Eugene Chulkov
+# @raycast.authorURL https://github.com/dev99problems
+
+LOCAL="/Users/<USER>/<SOME_PATH>/notes"
+REMOTE="/Users/<USER>/Library/Mobile Documents/com~apple~CloudDocs/notes"
+
+# for debugging
+# rsync -vran --exclude={".DS_Store",".idea"} "${LOCAL}/" $REMOTE
+
+# for doing stuff
+rsync -ra --exclude={".DS_Store",".idea"} "${LOCAL}/" $REMOTE
+


### PR DESCRIPTION
### Description
Adds the basic version of `synclair`

<img width="1084" alt="synclair_dry_run" src="https://user-images.githubusercontent.com/6503508/190903826-73410d90-0156-4616-9ebf-43bd7c8aa44d.png">


### What was done
- add: init version of synclair
- update: README with synclair description
